### PR TITLE
Subscribe to PubSub topic before Publishing

### DIFF
--- a/pubsub.go
+++ b/pubsub.go
@@ -94,6 +94,10 @@ func (p *PubsubValueStore) PutValue(ctx context.Context, key string, value []byt
 		p.mx.Unlock()
 	}
 
+	if err := p.Subscribe(key); err != nil {
+		return err
+	}
+
 	log.Debugf("PubsubPublish: publish value for key", key)
 	return p.ps.Publish(topic, value)
 }

--- a/pubsub.go
+++ b/pubsub.go
@@ -82,18 +82,6 @@ func (p *PubsubValueStore) PutValue(ctx context.Context, key string, value []byt
 	// Encode to "/record/base64url(key)"
 	topic := KeyToTopic(key)
 
-	p.mx.Lock()
-	_, bootstraped := p.subs[key]
-
-	if !bootstraped {
-		p.subs[key] = nil
-		p.mx.Unlock()
-
-		bootstrapPubsub(p.ctx, p.cr, p.host, topic)
-	} else {
-		p.mx.Unlock()
-	}
-
 	if err := p.Subscribe(key); err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR adds a PubSub `Subscribe` into the `PutValue` function before calling PubSub's `Publish`.

The reason is that the PubSubValueStore is a persistent single writer data store as indicated by its use of a cache for `GetValue` and its use of the `isBetter` function to determine what value to return. Were this node to `Put` a value that was not "better" than the value already on the network that would likely be a mistake. As a result it should `Subscribe` so that it has the current "best" value and can compare with that before sending out PubSub requests.

While there are scenarios in which the extra inbound messages could be deemed "not worth it" to the `Publisher`, I think you would be hard pressed to find them in this particular scenario. This is even more evident when noting that this router is mostly used by IPNS which plans to use the LWW PubSub implementation under development at libp2p/go-libp2p-pubsub#171.

@vyzo @raulk How does this sound to you?