### PR TITLE
fix: rename MinimalPubsub -> Pubsub interface and improve docs

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -123,6 +123,7 @@ github.com/libp2p/go-flow-metrics v0.0.1 h1:0gxuFd2GuK7IIP5pKljLwps6TvcuYgvG7Atq
 github.com/libp2p/go-flow-metrics v0.0.1/go.mod h1:Iv1GH0sG8DtYN3SVJ2eG221wMiNpZxBdp967ls1g+k8=
 github.com/libp2p/go-flow-metrics v0.0.2 h1:U5TvqfoyR6GVRM+bC15Ux1ltar1kbj6Zw6xOVR02CZs=
 github.com/libp2p/go-flow-metrics v0.0.2/go.mod h1:HeoSNUrOJVK1jEpDqVEiUOIXqhbnS27omG0uWU5slZs=
+github.com/libp2p/go-flow-metrics v0.0.3 h1:8tAs/hSdNvUiLgtlSy3mxwxWP4I9y/jlkPFT7epKdeM=
 github.com/libp2p/go-flow-metrics v0.0.3/go.mod h1:HeoSNUrOJVK1jEpDqVEiUOIXqhbnS27omG0uWU5slZs=
 github.com/libp2p/go-libp2p-blankhost v0.1.1 h1:X919sCh+KLqJcNRApj43xCSiQRYqOSI88Fdf55ngf78=
 github.com/libp2p/go-libp2p-blankhost v0.1.1/go.mod h1:pf2fvdLJPsC1FsVrNP3DUUvMzUts2dsLLBEpo1vW1ro=
@@ -326,6 +327,7 @@ github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.1 h1:8dP3SGL7MPB94crU3bEPplMPe83FI4EouesJUeFHv50=
 go.opencensus.io v0.22.1/go.mod h1:Ap50jQcDJrx6rB6VgeeFPtuPIf3wMRvRfrfYDO6+BmA=
+go.opencensus.io v0.22.2 h1:75k/FF0Q2YM8QYo07VPddOLBslDt1MZOdEslOHvmzAs=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
 golang.org/x/crypto v0.0.0-20170930174604-9419663f5a44/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=

--- a/pubsub.go
+++ b/pubsub.go
@@ -24,11 +24,10 @@ import (
 
 var log = logging.Logger("pubsub-valuestore")
 
-// MinimalPubsub allows us to provide the bare minimum pubsub functionality
-// to the router, while still using the same pubsub instance in other goroutines.
-// This is primarily done to allow callers to not have to worry about topic management
-// due to topics only allowing a single "joiner".
-type MinimalPubsub interface {
+// Pubsub is the minimal subset of the pubsub interface required by the pubsub
+// value store. This way, users can wrap the underlying pubsub implementation
+// without re-exporting/implementing the entire interface.
+type Pubsub interface {
 	RegisterTopicValidator(topic string, val pubsub.Validator, opts ...pubsub.ValidatorOpt) error
 	Join(topic string, opts ...pubsub.TopicOpt) (*pubsub.Topic, error)
 }
@@ -41,7 +40,7 @@ type watchGroup struct {
 type PubsubValueStore struct {
 	ctx context.Context
 	ds  ds.Datastore
-	ps  MinimalPubsub
+	ps  Pubsub
 
 	host  host.Host
 	fetch *fetchProtocol
@@ -81,7 +80,7 @@ func KeyToTopic(key string) string {
 type Option func(*PubsubValueStore) error
 
 // NewPubsubValueStore constructs a new ValueStore that gets and receives records through pubsub.
-func NewPubsubValueStore(ctx context.Context, host host.Host, ps MinimalPubsub, validator record.Validator, opts ...Option) (*PubsubValueStore, error) {
+func NewPubsubValueStore(ctx context.Context, host host.Host, ps Pubsub, validator record.Validator, opts ...Option) (*PubsubValueStore, error) {
 	psValueStore := &PubsubValueStore{
 		ctx: ctx,
 


### PR DESCRIPTION
* We might as well just call this Pubsub.
* Make the description a bit more generic.