### PR TITLE
wire a context in most of the go-ipfs data pipeline, connect them

### DIFF
--- a/fetch.go
+++ b/fetch.go
@@ -24,7 +24,7 @@ type fetchProtocol struct {
 	host host.Host
 }
 
-type getValue func(key string) ([]byte, error)
+type getValue func(ctx context.Context, key string) ([]byte, error)
 
 func newFetchProtocol(ctx context.Context, host host.Host, getData getValue) *fetchProtocol {
 	p := &fetchProtocol{ctx, host}
@@ -46,7 +46,7 @@ func (p *fetchProtocol) receive(s network.Stream, getData getValue) {
 		return
 	}
 
-	response, err := getData(msg.Identifier)
+	response, err := getData(p.ctx, msg.Identifier)
 	var respProto pb.FetchResponse
 
 	if err != nil {

--- a/fetch_test.go
+++ b/fetch_test.go
@@ -22,7 +22,7 @@ type datastore struct {
 	data map[string][]byte
 }
 
-func (d *datastore) Lookup(key string) ([]byte, error) {
+func (d *datastore) Lookup(ctx context.Context, key string) ([]byte, error) {
 	v, ok := d.data[key]
 	if !ok {
 		return nil, errors.New("key not found")


### PR DESCRIPTION
Master issue: https://github.com/ipfs/go-ipfs/issues/6803

This only do the wiring. Actual usage for cancellation, logging or tracing is
left for a future work.