### PR TITLE
Add WithDatastore option.

### DIFF
--- a/pubsub.go
+++ b/pubsub.go
@@ -589,3 +589,11 @@ func WithRebroadcastInitialDelay(duration time.Duration) Option {
 		return nil
 	}
 }
+
+// WithDatastore returns an option that overrides the default datastore.
+func WithDatastore(datastore ds.Datastore) Option {
+	return func(store *PubsubValueStore) error {
+		store.ds = datastore
+		return nil
+	}
+}


### PR DESCRIPTION
I am using the pubsub router to share user profiles.  I'd like to be able to have a last known value persisted for offline access.
I realize this can cause issues with "stale" values, but in my use case having an older version is better than having none at all.